### PR TITLE
Remove deprecated code

### DIFF
--- a/kork/parser.py
+++ b/kork/parser.py
@@ -17,7 +17,7 @@ from lark import Lark, Transformer, v_args
 
 from kork import ast
 
-GRAMMAR = """
+GRAMMAR = r"""
     program: statement+
 
     statement: function_decl

--- a/kork/prompt_adapter.py
+++ b/kork/prompt_adapter.py
@@ -7,9 +7,8 @@ The prompt adapter supports breaking the prompt into:
 """
 from typing import Any, Callable, List, Sequence, Tuple
 
-from langchain import BasePromptTemplate, PromptTemplate
 from langchain.schema import BaseMessage, HumanMessage, PromptValue, SystemMessage
-from pydantic import Extra
+from langchain_core.prompts import BasePromptTemplate, PromptTemplate
 
 
 class FewShotPromptValue(PromptValue):
@@ -21,7 +20,7 @@ class FewShotPromptValue(PromptValue):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
         arbitrary_types_allowed = True
 
     def to_string(self) -> str:

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -18,7 +18,7 @@ def test_code_chain() -> None:
         example_retriever=example_retriever,
     )
 
-    response = chain(inputs={"query": "blah"})
+    response = chain.invoke({"query": "blah"})
     # Why does the chain return a `query` key?
     assert sorted(response) == ["code", "environment", "errors", "query", "raw"]
     env = response.pop("environment")
@@ -43,7 +43,7 @@ def test_bad_program() -> None:
         example_retriever=example_retriever,
     )
 
-    response = chain(inputs={"query": "blah"})
+    response = chain.invoke({"query": "blah"})
     # Why does the chain return a `query` key?
     assert sorted(response) == ["code", "environment", "errors", "query", "raw"]
     assert response["raw"] == "<code>\nINVALID PROGRAM\n</code>"
@@ -67,7 +67,7 @@ def test_llm_output_missing_program() -> None:
         example_retriever=example_retriever,
     )
 
-    response = chain(inputs={"query": "blah"})
+    response = chain.invoke({"query": "blah"})
     # Why does the chain return a `query` key?
     assert sorted(response) == ["code", "environment", "errors", "query", "raw"]
     assert response["raw"] == "oops."
@@ -82,7 +82,7 @@ def test_from_defaults_instantiation() -> None:
     """Test from default instantiation."""
     llm = ToyChatModel(response="<code>\nvar x = 1;\n</code>")
     chain = CodeChain.from_defaults(llm=llm)
-    response = chain(inputs={"query": "blah"})
+    response = chain.invoke({"query": "blah"})
     # Why does the chain return a `query` key?
     assert sorted(response) == ["code", "environment", "errors", "query", "raw"]
     assert response["environment"].get_symbol("x") == 1

--- a/tests/test_prompt_adapter.py
+++ b/tests/test_prompt_adapter.py
@@ -1,4 +1,4 @@
-from langchain.prompts import PromptTemplate
+from langchain_core.prompts import PromptTemplate
 
 from kork.prompt_adapter import FewShotPromptValue, FewShotTemplate
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ from typing import Any, List, Optional
 
 from langchain.chat_models.base import BaseChatModel
 from langchain.schema import AIMessage, BaseMessage, ChatGeneration, ChatResult
-from pydantic import Extra
 
 
 class ToyChatModel(BaseChatModel):
@@ -11,7 +10,7 @@ class ToyChatModel(BaseChatModel):
     class Config:
         """Configuration for this pydantic object."""
 
-        extra = Extra.forbid
+        extra = "forbid"
         arbitrary_types_allowed = True
 
     def _generate(
@@ -28,3 +27,7 @@ class ToyChatModel(BaseChatModel):
         message = AIMessage(content=self.response)
         generation = ChatGeneration(message=message)
         return ChatResult(generations=[generation])
+
+    @property
+    def _llm_type(self) -> str:
+        return "toy"


### PR DESCRIPTION
Hello everyone,

Here are the list of changes:
- kork/chain.py:
  - Removal of `LLMChain` in favor of `RunnableSequence` as per LCEL
  - Fixing some imports
  - Removal of `pydantic.config.Extra` and instead assigning literals to the `extra` attribute
  - Removal of `cast()` and `predict_and_parse()` in favor of `.content` and `invoke()`
- kork/parser.py:
  - convert the GRAMMAR to a raw string
- kork/prompt_adapter.py:
  - Fixing some imports
  - Removal of `pydantic.config.Extra` and instead assigning literals to the `extra` attribute
- tests/test_chain.py:
  - removing `Chain.__call__()` in favor of `.invoke()`
- tests/test_prompt_adapter.py:
  - Fixing some imports
- tests/utils.py:
  - Removal of `pydantic.config.Extra` and instead assigning literals to the `extra` attribute
  - addition of property `_llm_type()` to ensure that the `test_chain` passes since `.invoke()` needs this property to function correctly

Merging this fixes #24. Please let me know if further changes are required or if I have missed something.

Cheers,
Sachin